### PR TITLE
feat: add futuristic theme and pwa support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,14 +2,15 @@ import { Toaster } from 'sonner';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
+import { PWAProvider } from '@/components/pwa-provider';
 
 import './globals.css';
 import { SessionProvider } from 'next-auth/react';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://chat.vercel.ai'),
-  title: 'Next.js Chatbot Template',
-  description: 'Next.js chatbot template using the AI SDK.',
+  title: 'Personal AI Agent',
+  description: 'Installable personal AI assistant with a futuristic UI.',
 };
 
 export const viewport = {
@@ -78,6 +79,7 @@ export default async function RootLayout({
           disableTransitionOnChange
         >
           <Toaster position="top-center" />
+          <PWAProvider />
           <SessionProvider>{children}</SessionProvider>
         </ThemeProvider>
       </body>

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Personal AI Agent',
+    short_name: 'AI Agent',
+    description:
+      'A futuristic, minimal personal AI assistant with smart-home and workspace tools.',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#020617',
+    theme_color: '#0ea5e9',
+    icons: [
+      {
+        src: '/icon.svg',
+        sizes: 'any',
+        type: 'image/svg+xml',
+      },
+    ],
+  };
+}

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -29,7 +29,7 @@ function PureChatHeader({
   const { width: windowWidth } = useWindowSize();
 
   return (
-    <header className="sticky top-0 flex items-center gap-2 bg-background px-2 py-1.5 md:px-2">
+    <header className='sticky top-0 flex items-center gap-2 border-primary/50 border-b bg-background/60 px-2 py-1.5 backdrop-blur-lg md:px-2'>
       <SidebarToggle />
 
       {(!open || windowWidth < 768) && (

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -156,7 +156,7 @@ export function Chat({
           selectedModelId={initialChatModel}
         />
 
-        <div className="sticky bottom-0 z-1 mx-auto flex w-full max-w-4xl gap-2 border-t-0 bg-background px-2 pb-3 md:px-4 md:pb-4">
+        <div className='neon-border sticky bottom-0 z-1 mx-auto flex w-full max-w-4xl gap-2 border-primary/50 border-t bg-background/60 px-2 pb-3 backdrop-blur-lg md:px-4 md:pb-4'>
           {!isReadonly && (
             <MultimodalInput
               chatId={id}

--- a/components/pwa-provider.tsx
+++ b/components/pwa-provider.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Registers the service worker required for PWA support.
+ * This runs once on the client and silently fails if service
+ * workers are not supported or registration fails.
+ */
+export function PWAProvider() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/sw.js')
+        .catch((err) => console.error('SW registration failed', err));
+    }
+  }, []);
+
+  return null;
+}

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#020617"/>
+  <path d="M256 96 352 256 256 416 160 256Z" fill="none" stroke="#0ea5e9" stroke-width="32" stroke-linejoin="round"/>
+</svg>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,5 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());
+
+// Placeholder fetch handler required for PWA installation.
+self.addEventListener('fetch', () => {});


### PR DESCRIPTION
## Summary
- add PWA manifest, service worker, and registration
- polish chat interface with neon borders and blur

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Serving HTML report at http://localhost:9323. Press Ctrl+C to quit.)*

------
https://chatgpt.com/codex/tasks/task_e_68c205b969748329b044812adb878d09