### PR TITLE
feat: add custom header and pwa support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
   <a href="https://chat-sdk.dev"><strong>Read Docs</strong></a> ·
   <a href="#features"><strong>Features</strong></a> ·
   <a href="#model-providers"><strong>Model Providers</strong></a> ·
-  <a href="#deploy-your-own"><strong>Deploy Your Own</strong></a> ·
   <a href="#running-locally"><strong>Running locally</strong></a>
 </p>
 <br/>
@@ -45,12 +44,6 @@ This template uses the [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) t
 **For non-Vercel deployments**: You need to provide an AI Gateway API key by setting the `AI_GATEWAY_API_KEY` environment variable in your `.env.local` file.
 
 With the [AI SDK](https://ai-sdk.dev/docs/introduction), you can also switch to direct LLM providers like [OpenAI](https://openai.com), [Anthropic](https://anthropic.com), [Cohere](https://cohere.com/), and [many more](https://ai-sdk.dev/providers/ai-sdk-providers) with just a few lines of code.
-
-## Deploy Your Own
-
-You can deploy your own version of the Next.js AI Chatbot to Vercel with one click:
-
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fai-chatbot&env=AUTH_SECRET&envDescription=Generate%20a%20random%20secret%20to%20use%20for%20authentication&envLink=https%3A%2F%2Fgenerate-secret.vercel.app%2F32&project-name=my-awesome-chatbot&repository-name=my-awesome-chatbot&demo-title=AI%20Chatbot&demo-description=An%20Open-Source%20AI%20Chatbot%20Template%20Built%20With%20Next.js%20and%20the%20AI%20SDK%20by%20Vercel&demo-url=https%3A%2F%2Fchat.vercel.ai&products=%5B%7B%22type%22%3A%22integration%22%2C%22protocol%22%3A%22storage%22%2C%22productSlug%22%3A%22neon%22%2C%22integrationSlug%22%3A%22neon%22%7D%2C%7B%22type%22%3A%22blob%22%7D%5D)
 
 ## Running locally
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,14 +2,15 @@ import { Toaster } from 'sonner';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { ThemeProvider } from '@/components/theme-provider';
+import { PWAProvider } from '@/components/pwa-provider';
 
 import './globals.css';
 import { SessionProvider } from 'next-auth/react';
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://chat.vercel.ai'),
-  title: 'Next.js Chatbot Template',
-  description: 'Next.js chatbot template using the AI SDK.',
+  title: 'Personal AI Agent',
+  description: 'Installable personal AI assistant with a futuristic UI.',
 };
 
 export const viewport = {
@@ -78,6 +79,7 @@ export default async function RootLayout({
           disableTransitionOnChange
         >
           <Toaster position="top-center" />
+          <PWAProvider />
           <SessionProvider>{children}</SessionProvider>
         </ThemeProvider>
       </body>

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Personal AI Agent',
+    short_name: 'AI Agent',
+    description:
+      'A futuristic, minimal personal AI assistant with smart-home and workspace tools.',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#020617',
+    theme_color: '#0ea5e9',
+    icons: [
+      {
+        src: '/icon.svg',
+        sizes: 'any',
+        type: 'image/svg+xml',
+      },
+    ],
+  };
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -34,8 +34,8 @@ export function AppSidebar({ user }: { user: User | undefined }) {
               }}
               className="flex flex-row items-center gap-3"
             >
-              <span className="cursor-pointer rounded-md px-2 font-semibold text-lg hover:bg-muted">
-                Chatbot
+              <span className='cursor-pointer rounded-md bg-gradient-to-r from-fuchsia-500 to-cyan-500 bg-clip-text px-2 font-semibold text-lg text-transparent'>
+                Personal Agent
               </span>
             </Link>
             <Tooltip>

--- a/components/chat-header.tsx
+++ b/components/chat-header.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useWindowSize } from 'usehooks-ts';
 
 import { SidebarToggle } from '@/components/sidebar-toggle';
 import { Button } from '@/components/ui/button';
-import { PlusIcon, VercelIcon } from './icons';
+import { PlusIcon } from './icons';
 import { useSidebar } from './ui/sidebar';
 import { memo } from 'react';
 import { type VisibilityType, VisibilitySelector } from './visibility-selector';
@@ -16,7 +15,7 @@ function PureChatHeader({
   chatId,
   selectedVisibilityType,
   isReadonly,
-  session,
+  session: _session,
 }: {
   chatId: string;
   selectedVisibilityType: VisibilityType;
@@ -29,43 +28,36 @@ function PureChatHeader({
   const { width: windowWidth } = useWindowSize();
 
   return (
-    <header className="sticky top-0 flex items-center gap-2 bg-background px-2 py-1.5 md:px-2">
-      <SidebarToggle />
+    <header className='sticky top-0 z-10 flex items-center justify-between border-primary/50 border-b bg-background/60 px-4 py-2 backdrop-blur-lg'>
+      <div className="flex items-center gap-2">
+        <SidebarToggle />
+        <span className='bg-gradient-to-r from-fuchsia-500 to-cyan-500 bg-clip-text font-semibold text-lg text-transparent tracking-widest'>
+          Personal Agent
+        </span>
+      </div>
 
-      {(!open || windowWidth < 768) && (
-        <Button
-          variant="outline"
-          className="order-2 ml-auto h-8 px-2 md:order-1 md:ml-0 md:h-fit md:px-2"
-          onClick={() => {
-            router.push('/');
-            router.refresh();
-          }}
-        >
-          <PlusIcon />
-          <span className="md:sr-only">New Chat</span>
-        </Button>
-      )}
+      <div className="flex items-center gap-2">
+        {(!open || windowWidth < 768) && (
+          <Button
+            variant="outline"
+            className="h-8 px-2 md:h-fit md:px-3"
+            onClick={() => {
+              router.push('/');
+              router.refresh();
+            }}
+          >
+            <PlusIcon />
+            <span className="md:sr-only">New Chat</span>
+          </Button>
+        )}
 
-      {!isReadonly && (
-        <VisibilitySelector
-          chatId={chatId}
-          selectedVisibilityType={selectedVisibilityType}
-          className="order-1 md:order-2"
-        />
-      )}
-
-      <Button
-        className="order-3 hidden bg-zinc-900 px-2 text-zinc-50 hover:bg-zinc-800 md:ml-auto md:flex md:h-fit dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
-        asChild
-      >
-        <Link
-          href={`https://vercel.com/new/clone?repository-url=https://github.com/vercel/ai-chatbot&env=AUTH_SECRET&envDescription=Learn more about how to get the API Keys for the application&envLink=https://github.com/vercel/ai-chatbot/blob/main/.env.example&demo-title=AI Chatbot&demo-description=An Open-Source AI Chatbot Template Built With Next.js and the AI SDK by Vercel.&demo-url=https://chat.vercel.ai&products=[{"type":"integration","protocol":"storage","productSlug":"neon","integrationSlug":"neon"},{"type":"integration","protocol":"storage","productSlug":"upstash-kv","integrationSlug":"upstash"},{"type":"blob"}]`}
-          target="_noblank"
-        >
-          <VercelIcon size={16} />
-          Deploy with Vercel
-        </Link>
-      </Button>
+        {!isReadonly && (
+          <VisibilitySelector
+            chatId={chatId}
+            selectedVisibilityType={selectedVisibilityType}
+          />
+        )}
+      </div>
     </header>
   );
 }

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -156,7 +156,7 @@ export function Chat({
           selectedModelId={initialChatModel}
         />
 
-        <div className="sticky bottom-0 z-1 mx-auto flex w-full max-w-4xl gap-2 border-t-0 bg-background px-2 pb-3 md:px-4 md:pb-4">
+        <div className='neon-border sticky bottom-0 z-1 mx-auto flex w-full max-w-4xl gap-2 border-primary/50 border-t bg-background/60 px-2 pb-3 backdrop-blur-lg md:px-4 md:pb-4'>
           {!isReadonly && (
             <MultimodalInput
               chatId={id}

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -56,24 +56,6 @@ export const AttachmentIcon = () => {
   );
 };
 
-export const VercelIcon = ({ size = 17 }) => {
-  return (
-    <svg
-      height={size}
-      strokeLinejoin="round"
-      viewBox="0 0 16 16"
-      width={size}
-      style={{ color: 'currentcolor' }}
-    >
-      <path
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M8 1L16 15H0L8 1Z"
-        fill="currentColor"
-      />
-    </svg>
-  );
-};
 
 export const GitIcon = () => {
   return (

--- a/components/pwa-provider.tsx
+++ b/components/pwa-provider.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Registers the service worker required for PWA support.
+ * This runs once on the client and silently fails if service
+ * workers are not supported or registration fails.
+ */
+export function PWAProvider() {
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker
+        .register('/sw.js')
+        .catch((err) => console.error('SW registration failed', err));
+    }
+  }, []);
+
+  return null;
+}

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#020617"/>
+  <path d="M256 96 352 256 256 416 160 256Z" fill="none" stroke="#0ea5e9" stroke-width="32" stroke-linejoin="round"/>
+</svg>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,5 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', () => self.clients.claim());
+
+// Placeholder fetch handler required for PWA installation.
+self.addEventListener('fetch', () => {});


### PR DESCRIPTION
## Summary
- add PWA manifest, service worker, and registration
- polish chat interface with neon borders and blur
- remove Vercel deploy link and introduce custom header

## Testing
- `pnpm lint`
- `pnpm test` *(serving HTML report at http://localhost:9323; tests not run to completion)*

------
https://chatgpt.com/codex/tasks/task_e_68c205b969748329b044812adb878d09