### PR TITLE
Add Home Assistant integration for chat control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,7 @@ POSTGRES_URL=****
 # Instructions to create a Redis store here:
 # https://vercel.com/docs/redis
 REDIS_URL=****
+
+# Home Assistant integration
+HOME_ASSISTANT_URL=https://home-assistant.local:8123
+HOME_ASSISTANT_TOKEN=****

--- a/README.md
+++ b/README.md
@@ -68,3 +68,12 @@ pnpm dev
 ```
 
 Your app template should now be running on [localhost:3000](http://localhost:3000).
+
+## Home Assistant integration
+
+Set the `HOME_ASSISTANT_URL` and `HOME_ASSISTANT_TOKEN` environment variables to allow the chatbot to proxy commands to your Home Assistant instance. The server exposes a new `/api/home-assistant` route that requires authentication and supports:
+
+- `POST /api/home-assistant` — call a Home Assistant service by providing the `domain`, `service`, optional `entityId`/`target`, and `data` payload.
+- `GET /api/home-assistant?entity_id=<entity>` — retrieve the latest state for an entity from Home Assistant.
+
+The AI assistant can also invoke these capabilities automatically through the `homeAssistant` tool once the environment variables are configured.

--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -25,6 +25,7 @@ import { createDocument } from '@/lib/ai/tools/create-document';
 import { updateDocument } from '@/lib/ai/tools/update-document';
 import { requestSuggestions } from '@/lib/ai/tools/request-suggestions';
 import { getWeather } from '@/lib/ai/tools/get-weather';
+import { homeAssistant } from '@/lib/ai/tools/home-assistant';
 import { isProductionEnvironment } from '@/lib/constants';
 import { myProvider } from '@/lib/ai/providers';
 import { entitlementsByUserType } from '@/lib/ai/entitlements';
@@ -165,6 +166,7 @@ export async function POST(request: Request) {
               ? []
               : [
                   'getWeather',
+                  'homeAssistant',
                   'createDocument',
                   'updateDocument',
                   'requestSuggestions',
@@ -172,6 +174,7 @@ export async function POST(request: Request) {
           experimental_transform: smoothStream({ chunking: 'word' }),
           tools: {
             getWeather,
+            homeAssistant,
             createDocument: createDocument({ session, dataStream }),
             updateDocument: updateDocument({ session, dataStream }),
             requestSuggestions: requestSuggestions({

--- a/app/(chat)/api/home-assistant/route.ts
+++ b/app/(chat)/api/home-assistant/route.ts
@@ -1,0 +1,117 @@
+import { auth } from '@/app/(auth)/auth';
+import { ChatSDKError } from '@/lib/errors';
+import {
+  callHomeAssistantService,
+  getHomeAssistantState,
+} from '@/lib/integrations/home-assistant';
+import { z } from 'zod';
+
+export const runtime = 'nodejs';
+
+const entityIdSchema = z.union([z.string().min(1), z.array(z.string().min(1))]);
+
+const targetSchema = z
+  .object({
+    entity_id: entityIdSchema.optional(),
+    device_id: z.union([z.string().min(1), z.array(z.string().min(1))]).optional(),
+    area_id: z.union([z.string().min(1), z.array(z.string().min(1))]).optional(),
+  })
+  .strict()
+  .optional();
+
+const callServiceSchema = z
+  .object({
+    domain: z.string().min(1),
+    service: z.string().min(1),
+    entityId: entityIdSchema.optional(),
+    entity_id: entityIdSchema.optional(),
+    target: targetSchema,
+    data: z.record(z.any()).optional(),
+  })
+  .strict();
+
+type CallServicePayload = z.infer<typeof callServiceSchema>;
+
+export async function POST(request: Request) {
+  const session = await auth();
+
+  if (!session?.user) {
+    return new ChatSDKError('unauthorized:chat').toResponse();
+  }
+
+  let body: CallServicePayload;
+
+  try {
+    const json = await request.json();
+    body = callServiceSchema.parse(json);
+  } catch (error) {
+    return new ChatSDKError(
+      'bad_request:api',
+      "Invalid request body. Expected domain, service, and optional entity information.",
+    ).toResponse();
+  }
+
+  const entityId = body.entityId ?? body.entity_id;
+
+  try {
+    const result = await callHomeAssistantService({
+      domain: body.domain,
+      service: body.service,
+      entityId,
+      target: body.target,
+      data: body.data,
+    });
+
+    return Response.json(
+      {
+        success: true,
+        result,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    if (error instanceof ChatSDKError) {
+      return error.toResponse();
+    }
+
+    console.error('Error calling Home Assistant service:', error);
+    return new ChatSDKError('offline:api').toResponse();
+  }
+}
+
+export async function GET(request: Request) {
+  const session = await auth();
+
+  if (!session?.user) {
+    return new ChatSDKError('unauthorized:chat').toResponse();
+  }
+
+  const { searchParams } = new URL(request.url);
+  const entityId = searchParams.get('entity_id') ?? searchParams.get('entityId');
+
+  if (!entityId) {
+    return new ChatSDKError(
+      'bad_request:api',
+      'Parameter entity_id is required to fetch an entity state.',
+    ).toResponse();
+  }
+
+  try {
+    const state = await getHomeAssistantState(entityId);
+
+    return Response.json(
+      {
+        success: true,
+        state,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    if (error instanceof ChatSDKError) {
+      return error.toResponse();
+    }
+
+    console.error('Error fetching Home Assistant state:', error);
+    return new ChatSDKError('offline:api').toResponse();
+  }
+}

--- a/lib/ai/tools/home-assistant.ts
+++ b/lib/ai/tools/home-assistant.ts
@@ -1,0 +1,86 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { ChatSDKError } from '@/lib/errors';
+import {
+  callHomeAssistantService,
+  type HomeAssistantTarget,
+} from '@/lib/integrations/home-assistant';
+
+const entityIdSchema = z.union([z.string().min(1), z.array(z.string().min(1))]);
+
+const targetSchema: z.ZodType<HomeAssistantTarget | undefined> = z
+  .object({
+    entity_id: entityIdSchema.optional(),
+    device_id: z.union([z.string().min(1), z.array(z.string().min(1))]).optional(),
+    area_id: z.union([z.string().min(1), z.array(z.string().min(1))]).optional(),
+  })
+  .strict()
+  .optional();
+
+export const homeAssistant = tool({
+  description:
+    'Call Home Assistant services to control devices. Provide the domain (light, switch, climate, etc.), service (turn_on, turn_off, etc.), and the target entity or additional data required for the call.',
+  inputSchema: z.object({
+    domain: z
+      .string()
+      .min(1)
+      .describe('Home Assistant domain such as light, switch, climate, cover, etc.'),
+    service: z
+      .string()
+      .min(1)
+      .describe('Service to invoke within the domain, for example turn_on, turn_off, set_temperature.'),
+    entityId: entityIdSchema
+      .optional()
+      .describe('Fully qualified entity_id (e.g. light.living_room) or an array of entity_ids to target.'),
+    target: targetSchema.describe(
+      'Optional target block for the service call. Use when a service expects target with entity_id, device_id, or area_id.',
+    ),
+    data: z
+      .record(z.any())
+      .optional()
+      .describe('Additional service data payload as required by the Home Assistant service.'),
+  }),
+  execute: async ({ domain, service, entityId, target, data }) => {
+    try {
+      const result = await callHomeAssistantService({
+        domain,
+        service,
+        entityId,
+        target,
+        data,
+      });
+
+      return {
+        success: true,
+        result,
+      };
+    } catch (error) {
+      if (error instanceof ChatSDKError) {
+        const response: {
+          success: false;
+          error: string;
+          code: string;
+          details?: string;
+        } = {
+          success: false,
+          error: error.message,
+          code: `${error.type}:${error.surface}`,
+        };
+
+        if (error.cause) {
+          response.details =
+            typeof error.cause === 'string'
+              ? error.cause
+              : String(error.cause);
+        }
+
+        return response;
+      }
+
+      return {
+        success: false,
+        error: 'Unexpected error while interacting with Home Assistant.',
+      };
+    }
+  },
+});

--- a/lib/integrations/home-assistant.ts
+++ b/lib/integrations/home-assistant.ts
@@ -1,0 +1,238 @@
+import { ChatSDKError } from '@/lib/errors';
+
+type EntityId = string | string[];
+
+export interface HomeAssistantTarget {
+  entity_id?: EntityId;
+  device_id?: string | string[];
+  area_id?: string | string[];
+}
+
+export interface CallHomeAssistantServiceParams {
+  domain: string;
+  service: string;
+  entityId?: EntityId;
+  target?: HomeAssistantTarget;
+  data?: Record<string, unknown>;
+}
+
+function getHomeAssistantConfig() {
+  const baseUrl = process.env.HOME_ASSISTANT_URL;
+  const token = process.env.HOME_ASSISTANT_TOKEN;
+
+  if (!baseUrl || !token) {
+    throw new ChatSDKError(
+      'bad_request:api',
+      'Home Assistant integration is not configured.',
+    );
+  }
+
+  return {
+    baseUrl,
+    token,
+  };
+}
+
+function normalizePath(path: string) {
+  return path.replace(/\/+/g, '/');
+}
+
+export async function callHomeAssistantService({
+  domain,
+  service,
+  entityId,
+  target,
+  data,
+}: CallHomeAssistantServiceParams) {
+  const { baseUrl, token } = getHomeAssistantConfig();
+  const trimmedDomain = domain.trim();
+  const trimmedService = service.trim();
+
+  if (!trimmedDomain || !trimmedService) {
+    throw new ChatSDKError(
+      'bad_request:api',
+      'Both domain and service are required to call Home Assistant.',
+    );
+  }
+
+  const payload: Record<string, unknown> = {};
+
+  if (typeof entityId !== 'undefined') {
+    if (Array.isArray(entityId)) {
+      const normalizedEntityIds = entityId
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0);
+
+      if (normalizedEntityIds.length > 0) {
+        payload.entity_id = normalizedEntityIds;
+      }
+    } else {
+      const normalizedEntityId = entityId.trim();
+
+      if (normalizedEntityId) {
+        payload.entity_id = normalizedEntityId;
+      }
+    }
+  }
+
+  if (target) {
+    const normalizedTargetEntries = Object.entries(target)
+      .map(([key, value]) => {
+        if (value === undefined || value === null) {
+          return null;
+        }
+
+        if (Array.isArray(value)) {
+          const cleanedValues = value
+            .map((item) => item.trim())
+            .filter((item) => item.length > 0);
+
+          if (cleanedValues.length === 0) {
+            return null;
+          }
+
+          return [key, cleanedValues] as const;
+        }
+
+        if (typeof value === 'string') {
+          const trimmedValue = value.trim();
+
+          if (!trimmedValue) {
+            return null;
+          }
+
+          return [key, trimmedValue] as const;
+        }
+
+        return [key, value] as const;
+      })
+      .filter((entry): entry is [string, unknown] => entry !== null);
+
+    if (normalizedTargetEntries.length > 0) {
+      payload.target = Object.fromEntries(normalizedTargetEntries);
+    }
+  }
+
+  if (data && Object.keys(data).length > 0) {
+    payload.data = data;
+  }
+
+  const url = new URL(
+    normalizePath(`/api/services/${trimmedDomain}/${trimmedService}`),
+    baseUrl,
+  );
+
+  let response: Response;
+
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (error) {
+    throw new ChatSDKError(
+      'offline:api',
+      'Unable to reach the configured Home Assistant instance.',
+    );
+  }
+
+  const responseText = await response.text();
+
+  if (!response.ok) {
+    const message = responseText
+      ? `Home Assistant responded with ${response.status}: ${responseText}`
+      : `Home Assistant responded with ${response.status}.`;
+
+    throw new ChatSDKError('bad_request:api', message);
+  }
+
+  if (!responseText) {
+    return null;
+  }
+
+  const isJson = response.headers
+    .get('content-type')
+    ?.toLowerCase()
+    .includes('application/json');
+
+  if (isJson) {
+    try {
+      return JSON.parse(responseText);
+    } catch (error) {
+      throw new ChatSDKError(
+        'bad_request:api',
+        'Failed to parse JSON response from Home Assistant.',
+      );
+    }
+  }
+
+  return responseText;
+}
+
+export async function getHomeAssistantState(entityId: string) {
+  const { baseUrl, token } = getHomeAssistantConfig();
+  const trimmedEntityId = entityId.trim();
+
+  if (!trimmedEntityId) {
+    throw new ChatSDKError(
+      'bad_request:api',
+      'An entity ID is required to read Home Assistant state.',
+    );
+  }
+
+  const url = new URL(
+    normalizePath(`/api/states/${encodeURIComponent(trimmedEntityId)}`),
+    baseUrl,
+  );
+
+  let response: Response;
+
+  try {
+    response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (error) {
+    throw new ChatSDKError(
+      'offline:api',
+      'Unable to reach the configured Home Assistant instance.',
+    );
+  }
+
+  if (response.status === 404) {
+    throw new ChatSDKError(
+      'not_found:api',
+      `Entity ${trimmedEntityId} was not found in Home Assistant.`,
+    );
+  }
+
+  const responseText = await response.text();
+
+  if (!response.ok) {
+    const message = responseText
+      ? `Home Assistant responded with ${response.status}: ${responseText}`
+      : `Home Assistant responded with ${response.status}.`;
+
+    throw new ChatSDKError('bad_request:api', message);
+  }
+
+  if (!responseText) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(responseText);
+  } catch (error) {
+    throw new ChatSDKError(
+      'bad_request:api',
+      'Failed to parse JSON response from Home Assistant.',
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a server route at `/api/home-assistant` that proxies authenticated service calls and state lookups to Home Assistant using new environment variables
- expose a `homeAssistant` AI tool so chats can trigger Home Assistant automations alongside existing tools
- document the integration and configuration in `.env.example` and the README
- ensure the Home Assistant API route executes on the Node.js runtime and coerce tool error details to strings so the deployment build succeeds

## Testing
- pnpm exec tsc --noEmit *(fails: tests/e2e/session.test.ts expects a Request but receives possible null from `redirectedFrom()`)*

------
https://chatgpt.com/codex/tasks/task_e_68c96553daf88329afec06eeb3a18a9c